### PR TITLE
Fix inline notes with tags inside a hyperlink

### DIFF
--- a/modules/fb2html.py
+++ b/modules/fb2html.py
@@ -780,7 +780,7 @@ class Fb2XHTML:
                 self.inline_image_mode = False
 
             if self.current_notes:
-                if self.notes_mode == 'inline':
+                if self.notes_mode == 'inline' and tag == 'span':
                     self.buff.append('<span class="inlinenote">[%s]</span>' % save_html(
                         self.insert_hyphenation(''.join(self.current_notes[0][1]))))
                     self.current_notes = []


### PR DESCRIPTION
Текст сноски в режиме inline не отображался (скрывался тегом `span class="inlineanchor"`), если внутри гиперссылки присутствовали теги (например, `<sup>`).

Проблема обнаружена в [книге Толстого](http://flibusta.is/b/142847) (в комментариях) и может быть легко воспроизведена [тестовым файлом](http://rgho.st/6RYnzpsJP).