### PR TITLE
Logging fixes and improvements

### DIFF
--- a/fb2epub.config
+++ b/fb2epub.config
@@ -1,10 +1,9 @@
 <?xml version='1.0' encoding='utf-8'?>
 <settings>
   <debug>False</debug>
-  <!--logFile>debug.log</logFile>
-  <logLevel>DEBUG</logLevel-->
-  <logFile/>
-  <logLevel>ERROR</logLevel>
+  <consoleLevel>INFO</consoleLevel>
+  <logFile></logFile>
+  <logLevel>DEBUG</logLevel>
   <outputFormat>epub</outputFormat>
   <kindleCompressionLevel>1</kindleCompressionLevel>
   <noDropcapsSymbols>'"-.…0123456789‒–—«»</noDropcapsSymbols>

--- a/fb2mobi.config
+++ b/fb2mobi.config
@@ -1,10 +1,9 @@
 <?xml version='1.0' encoding='utf-8'?>
 <settings>
   <debug>False</debug>
-  <logFile/>
-  <logLevel>ERROR</logLevel>
-  <!--logFile>debug.log</logFile>
-  <logLevel>DEBUG</logLevel-->
+  <consoleLevel>INFO</consoleLevel>
+  <logFile></logFile>
+  <logLevel>DEBUG</logLevel>
   <outputFormat>mobi</outputFormat>
   <kindleCompressionLevel>1</kindleCompressionLevel>
   <noDropcapsSymbols>'"-.…0123456789‒–—«»</noDropcapsSymbols>

--- a/fb2mobi.py
+++ b/fb2mobi.py
@@ -416,25 +416,26 @@ def process(args):
             config.log_file = args.log
         if args.loglevel:
             config.log_level = args.loglevel
+        if args.consolelevel:
+            config.console_level = args.consolelevel
         if args.recursive:
             config.recursive = True
         if args.nc:
             config.mhl = True
 
     log = logging.getLogger('fb2mobi')
-    log.setLevel(get_log_level(config.log_level))
+    log.setLevel("DEBUG")
+
+    log_stream_handler = logging.StreamHandler()
+    log_stream_handler.setLevel(get_log_level(config.console_level))
+    log_stream_handler.setFormatter(logging.Formatter('%(levelname)s: %(message)s'))
+    log.addHandler(log_stream_handler)
 
     if config.log_file:
-        log_handler = logging.FileHandler(filename=config.log_file, mode='a', encoding='utf-8')
-        log_handler.setLevel(get_log_level(config.log_level))
-        log_handler.setFormatter(logging.Formatter('[%(asctime)s] %(levelname)s: %(message)s'))
-    else:
-        log_handler = logging.StreamHandler()
-        log_handler.setLevel(get_log_level(config.log_level))
-        log_handler.setFormatter(logging.Formatter('%(levelname)s: %(message)s'))
-
-    if len(log.handlers) == 0:
-        log.addHandler(log_handler)
+        log_file_handler = logging.FileHandler(filename=config.log_file, mode='a', encoding='utf-8')
+        log_file_handler.setLevel(get_log_level(config.log_level))
+        log_file_handler.setFormatter(logging.Formatter('[%(asctime)s] %(levelname)s: %(message)s'))
+        log.addHandler(log_file_handler)
 
     config.log = log
 
@@ -537,6 +538,7 @@ if __name__ == '__main__':
     argparser.add_argument('-d', '--debug', action='store_true', default=None, help='Keep imtermediate files in desctination directory')
     argparser.add_argument('--log', type=str, default=None, help='Log file name')
     argparser.add_argument('--log-level', dest='loglevel', type=str, default=None, help='Log level: INFO, ERROR, CRITICAL, DEBUG')
+    argparser.add_argument('--console-level', dest='consolelevel', type=str, default=None, help='Log level: INFO, ERROR, CRITICAL, DEBUG')
 
     hyphenate_group = argparser.add_mutually_exclusive_group()
     hyphenate_group.add_argument('--hyphenate', dest='hyphenate', action='store_true', default=None, help='Turn on hyphenation')

--- a/fb2mobi.py
+++ b/fb2mobi.py
@@ -212,10 +212,15 @@ def process_file(config, infile, outfile=None):
     else:
         # Конвертируем в html
         config.log.info('Converting fb2 to html...')
-        fb2parser = Fb2XHTML(infile, outfile, temp_dir, config)
-        fb2parser.generate()
-        document_id = fb2parser.book_uuid
-        infile = os.path.join(temp_dir, 'OEBPS', 'content.opf')
+        try:
+            fb2parser = Fb2XHTML(infile, outfile, temp_dir, config)
+            fb2parser.generate()
+            document_id = fb2parser.book_uuid
+            infile = os.path.join(temp_dir, 'OEBPS', 'content.opf')
+        except:
+            config.log.critical('Error while converting file "{0}"'.format(infile))
+            config.log.debug('Getting details', exc_info=True)
+            return
 
     config.log.info('Processing took {0} sec.'.format(round(time.clock() - start_time, 2)))
 
@@ -253,6 +258,7 @@ def process_file(config, infile, outfile=None):
             else:
                 config.log.critical(e.winerror)
                 config.log.critical(e.strerror)
+                config.log.debug('Getting details', exc_info=True, stack_info=True)
                 raise e
 
     elif config.output_format.lower() == 'epub':

--- a/modules/config.py
+++ b/modules/config.py
@@ -15,6 +15,7 @@ class ConverterConfig:
         self.log_file = None
         self.original_log_file = None
         self.log_level = 'Info'
+        self.console_level = 'Info'
         self.output_format = 'epub'
         self.kindle_compression_level = 1
         self.no_dropcaps_symbols = '\'"-.…0123456789‒–—«»'
@@ -102,6 +103,9 @@ class ConverterConfig:
 
             elif e.tag == 'logLevel':
                 self.log_level = e.text
+
+            elif e.tag == 'consoleLevel':
+                self.console_level = e.text
 
             elif e.tag == 'outputFormat':
                 self.output_format = e.text
@@ -339,6 +343,7 @@ class ConverterConfig:
                    E('debug', str(self.debug)),
                    E('logFile', self.original_log_file) if self.original_log_file else E('logFile'),
                    E('logLevel', self.log_level),
+                   E('consoleLevel', self.console_level),
                    E('outputFormat', self.output_format),
                    E('kindleCompressionLevel', str(self.kindle_compression_level)),
                    E('noDropcapsSymbols', self.no_dropcaps_symbols),


### PR DESCRIPTION
Первый патч обеспечивает корректный вывод логов в указанное место при некоторых вариантах падения конвертера.

Второй патч добавляет возможность вывода логов одновременно в файл и на экран, что во многих случаях представляется удобным (лог-файл для отладки плюс наблюдение за процессом конвертации через консоль). Уровень вывода на экран настраивается отдельно, ключом командной строки `--console-level` и параметром конфигурационного файла `<consoleLevel>`