### PR TITLE
Adds an option to make PNG images non-transparent

### DIFF
--- a/fb2epub.config
+++ b/fb2epub.config
@@ -42,6 +42,7 @@
       <generateAnnotationPage>True</generateAnnotationPage>
       <generateOPFGuide>True</generateOPFGuide>
       <kindleRemovePersonalLabel>True</kindleRemovePersonalLabel>
+      <removePngTransparency>False</removePngTransparency>
       <vignettes>
         <vignette level="default">
           <beforeTitle>profiles/vignettes/title_before.png</beforeTitle>
@@ -79,6 +80,7 @@
       <generateAnnotationPage>True</generateAnnotationPage>
       <generateOPFGuide>True</generateOPFGuide>
       <kindleRemovePersonalLabel>True</kindleRemovePersonalLabel>
+      <removePngTransparency>False</removePngTransparency>
       <vignettes/>
     </profile>
     <profile description="No hyphenation" name="nohyph">
@@ -100,6 +102,7 @@
       <generateAnnotationPage>True</generateAnnotationPage>
       <generateOPFGuide>True</generateOPFGuide>
       <kindleRemovePersonalLabel>True</kindleRemovePersonalLabel>
+      <removePngTransparency>False</removePngTransparency>
       <vignettes/>
     </profile>
     <profile description="Vignettes" name="vignettes">
@@ -121,6 +124,7 @@
       <generateAnnotationPage>True</generateAnnotationPage>
       <generateOPFGuide>True</generateOPFGuide>
       <kindleRemovePersonalLabel>True</kindleRemovePersonalLabel>
+      <removePngTransparency>False</removePngTransparency>
       <vignettes>
         <vignette level="default">
           <beforeTitle>profiles/vignettes/title_before.png</beforeTitle>
@@ -158,6 +162,7 @@
       <generateAnnotationPage>True</generateAnnotationPage>
       <generateOPFGuide>True</generateOPFGuide>
       <kindleRemovePersonalLabel>True</kindleRemovePersonalLabel>
+      <removePngTransparency>False</removePngTransparency>
       <vignettes/>
     </profile>
   </profiles>

--- a/fb2mobi.config
+++ b/fb2mobi.config
@@ -42,6 +42,7 @@
       <generateAnnotationPage>True</generateAnnotationPage>
       <generateOPFGuide>True</generateOPFGuide>
       <kindleRemovePersonalLabel>True</kindleRemovePersonalLabel>
+      <removePngTransparency>False</removePngTransparency>
       <vignettes>
         <vignette level="default">
           <beforeTitle>profiles/vignettes/title_before.png</beforeTitle>
@@ -79,6 +80,7 @@
       <generateAnnotationPage>True</generateAnnotationPage>
       <generateOPFGuide>True</generateOPFGuide>
       <kindleRemovePersonalLabel>True</kindleRemovePersonalLabel>
+      <removePngTransparency>False</removePngTransparency>
       <vignettes/>
     </profile>
     <profile description="No hyphenation" name="nohyph">
@@ -100,6 +102,7 @@
       <generateAnnotationPage>True</generateAnnotationPage>
       <generateOPFGuide>True</generateOPFGuide>
       <kindleRemovePersonalLabel>True</kindleRemovePersonalLabel>
+      <removePngTransparency>False</removePngTransparency>
       <vignettes/>
     </profile>
     <profile description="Vignettes" name="vignettes">
@@ -121,6 +124,7 @@
       <generateAnnotationPage>True</generateAnnotationPage>
       <generateOPFGuide>True</generateOPFGuide>
       <kindleRemovePersonalLabel>True</kindleRemovePersonalLabel>
+      <removePngTransparency>False</removePngTransparency>
       <vignettes>
         <vignette level="default">
           <beforeTitle>profiles/vignettes/title_before.png</beforeTitle>
@@ -158,6 +162,7 @@
       <generateAnnotationPage>True</generateAnnotationPage>
       <generateOPFGuide>True</generateOPFGuide>
       <kindleRemovePersonalLabel>True</kindleRemovePersonalLabel>
+      <removePngTransparency>False</removePngTransparency>
       <vignettes/>
     </profile>
   </profiles>

--- a/fb2mobi.py
+++ b/fb2mobi.py
@@ -483,6 +483,8 @@ def process(args):
             config.current_profile['tocTitle'] = args.toctitle
         if args.chapteronnewpage is not None:
             config.current_profile['chapterOnNewPage'] = args.chapteronnewpage
+        if args.removepngtransparency is not None:
+            config.current_profile['removePngTransparency'] = args.removepngtransparency
         if args.noMOBIoptimization:
             config.noMOBIoptimization = args.noMOBIoptimization
         if args.sendtokindle is not None:
@@ -592,6 +594,10 @@ if __name__ == '__main__':
     tocplace_group = argparser.add_mutually_exclusive_group()
     tocplace_group.add_argument('--toc-before-body', dest='tocbeforebody', action='store_true', default=None, help='Put TOC at the book beginning')
     tocplace_group.add_argument('--toc-after-body', dest='tocbeforebody', action='store_false', default=None, help='Put TOC at the book end')
+
+    pngtransparency_group = argparser.add_mutually_exclusive_group()
+    pngtransparency_group.add_argument('--remove-png-transparency', dest='removepngtransparency', action='store_true', default=None, help='Remove transparency in PNG images')
+    pngtransparency_group.add_argument('--no-remove-png-transparency', dest='removepngtransparency', action='store_false', default=None, help='Do not remove transparency in PNG images')
 
     # Для совместимости с MyHomeLib добавляем аргументы, которые передает MHL в fb2mobi.exe
     argparser.add_argument('-nc', action='store_true', default=False, help='For MyHomeLib compatibility')

--- a/modules/config.py
+++ b/modules/config.py
@@ -64,6 +64,7 @@ class ConverterConfig:
         self.profiles['default']['generateAnnotationPage'] = True
         self.profiles['default']['generateOPFGuide'] = True
         self.profiles['default']['kindleRemovePersonalLabel'] = True
+        self.profiles['default']['removePngTransparency'] = False
 
         self.current_profile = {}
         self.mhl = False
@@ -171,6 +172,7 @@ class ConverterConfig:
                     self.profiles[prof_name]['generateOPFGuide'] = True
                     self.profiles[prof_name]['flatTOC'] = True
                     self.profiles[prof_name]['kindleRemovePersonalLabel'] = True
+                    self.profiles[prof_name]['removePngTransparency'] = False
 
                     for p in prof:
                         if p.tag == 'hyphens':
@@ -208,6 +210,9 @@ class ConverterConfig:
 
                         elif p.tag == 'kindleRemovePersonalLabel':
                             self.profiles[prof_name]['kindleRemovePersonalLabel'] = p.text.lower() == 'true'
+
+                        elif p.tag == 'removePngTransparency':
+                            self.profiles[prof_name]['removePngTransparency'] = p.text.lower() == 'true'
 
                         elif p.tag == 'generateAnnotationPage':
                             self.profiles[prof_name]['generateAnnotationPage'] = p.text.lower() == 'true'
@@ -309,6 +314,7 @@ class ConverterConfig:
                             E('generateAnnotationPage', str(self.profiles[p]['generateAnnotationPage'])),
                             E('generateOPFGuide', str(self.profiles[p]['generateOPFGuide'])),
                             E('kindleRemovePersonalLabel', str(self.profiles[p]['kindleRemovePersonalLabel'])),
+                            E('removePngTransparency', str(self.profiles[p]['removePngTransparency'])),
                             E('vignettes',
                               *self._getVignettes(p)
                               ),


### PR DESCRIPTION
PNG images with transparency are not officially supported by Kindle, and often they are displayed incorrectly. The problem can be seen on Kindle 4NT, on latest Kindle Previewer and probably on other Kindle readers.

Problem was noticed in [several](http://flibusta.is/b/331289) [books](http://flibusta.is/b/297605). Test file with various types of transparent PNG images can be found [here](http://rgho.st/6YFmqCgyd).

Now converter has an option to make these images non-transparent, with white background. By default it's disabled and can be enabled by `<removePngTransparency>` config line or `--remove-png-transparency` command-line argument.