### PR TITLE
Fix smtplib.SMTPServerDisconnected error

### DIFF
--- a/modules/sendtokindle.py
+++ b/modules/sendtokindle.py
@@ -30,8 +30,7 @@ class SendToKindle:
             fname = os.path.basename(file_path)
             msg.attach(MIMEApplication(open(file_path, 'rb').read(), Content_Disposition='attachment; filename="%s"' % fname, Name=fname))
 
-        mail_server = smtplib.SMTP(host=self.smtp_server, port=self.smtp_port)
-        mail_server.starttls()
+        mail_server = smtplib.SMTP_SSL(host=self.smtp_server, port=self.smtp_port)
         mail_server.login(self.smtp_login, self.smtp_password)
         mail_server.sendmail(self.user_email, self.kindle_email, msg.as_string())
         mail_server.quit()


### PR DESCRIPTION
While trying to send book to Fastmail and Gmail I am receiving error
"smtplib.SMTPServerDisconnected: Connection unexpectedly closed"

Tested this fix for both of these mail providers on Ubuntu 16.04 LTS.

I used code from fb2conv.